### PR TITLE
Fix updating of deploy-keys

### DIFF
--- a/bitbucket/repo_keys.go
+++ b/bitbucket/repo_keys.go
@@ -75,18 +75,9 @@ func (r *RepoKeyResource) Create(owner, slug, key, label string) (*Key, error) {
 // Creates a key on the specified account. You must supply a valid key
 // that is unique across the Bitbucket service.
 func (r *RepoKeyResource) Update(owner, slug, key, label string, id int) (*Key, error) {
-
-	values := url.Values{}
-	values.Add("key", key)
-	values.Add("label", label)
-
-	k := Key{}
-	path := fmt.Sprintf("/repositories/%s/%s/deploy-keys/%v", owner, slug, id)
-	if err := r.client.do("PUT", path, nil, values, &k); err != nil {
-		return nil, err
-	}
-
-	return &k, nil
+	// There is actually no API to update an existing key
+	r.Delete(owner, slug, id)
+	return r.Create(owner, slug, key, label)
 }
 
 func (r *RepoKeyResource) CreateUpdate(owner, slug, key, label string) (*Key, error) {


### PR DESCRIPTION
Bitbucket doesn't provide any API to update keys, so we need to
delete the existing key and create a new one.
