### PR TITLE
sometimes we can't get branch name when listing branches

### DIFF
--- a/bitbucket/repos.go
+++ b/bitbucket/repos.go
@@ -88,7 +88,8 @@ func (r *RepoResource) ListBranches(owner, slug string) ([]*Branch, error) {
 	// The list is returned in a map ...
 	// we really want a slice
 	branches := []*Branch{}
-	for _, branch := range branchMap {
+	for name, branch := range branchMap {
+		branch.Branch = name
 		branches = append(branches, branch)
 	}
 


### PR DESCRIPTION
try this example:

GET https://bitbucket.org/api/1.0/repositories/sakeven/tutorial/branches

we get json like this:

``` json
{
  "Haha": {
    "node": "82c782cf2925",
    "files": [
      {
        "type": "modified",
        "file": "README.md"
      }
    ],
    "branches": [
      "Haha",
      "Nias",
      "master"
    ],
    "raw_author": "Daniel  Stevens <dstevens@atlassian.com>",
    "utctimestamp": "2015-02-12 18:11:07+00:00",
    "author": "dans9190",
    "timestamp": "2015-02-12 19:11:07",
    "raw_node": "82c782cf29258f58a630d0ce2728bf8c85d4e03d",
    "parents": [
      "665e2201044d"
    ],
    "branch": null,
    "message": "README.md edited online with Bitbucket",
    "revision": null,
    "size": -1
  },
  "master": {
    "node": "82c782cf2925",
    "files": [
      {
        "type": "modified",
        "file": "README.md"
      }
    ],
    "branches": [
      "Haha",
      "Nias",
      "master"
    ],
    "raw_author": "Daniel  Stevens <dstevens@atlassian.com>",
    "utctimestamp": "2015-02-12 18:11:07+00:00",
    "author": "dans9190",
    "timestamp": "2015-02-12 19:11:07",
    "raw_node": "82c782cf29258f58a630d0ce2728bf8c85d4e03d",
    "parents": [
      "665e2201044d"
    ],
    "branch": null,
    "message": "README.md edited online with Bitbucket",
    "revision": null,
    "size": -1
  },
  "Nias": {
    "node": "82c782cf2925",
    "files": [
      {
        "type": "modified",
        "file": "README.md"
      }
    ],
    "branches": [
      "Haha",
      "Nias",
      "master"
    ],
    "raw_author": "Daniel  Stevens <dstevens@atlassian.com>",
    "utctimestamp": "2015-02-12 18:11:07+00:00",
    "author": "dans9190",
    "timestamp": "2015-02-12 19:11:07",
    "raw_node": "82c782cf29258f58a630d0ce2728bf8c85d4e03d",
    "parents": [
      "665e2201044d"
    ],
    "branch": null,
    "message": "README.md edited online with Bitbucket",
    "revision": null,
    "size": -1
  }
}
```
